### PR TITLE
Added aliases for specific datatypes used in project

### DIFF
--- a/back_end/account/account.go
+++ b/back_end/account/account.go
@@ -1,5 +1,7 @@
 package account
 
+import "digital-voting/signature/keys"
+
 type Type uint8
 
 const (
@@ -9,6 +11,6 @@ const (
 )
 
 type Account struct {
-	Type      Type     `json:"type"`
-	PublicKey [33]byte `json:"public_key"`
+	Type      Type                `json:"type"`
+	PublicKey keys.PublicKeyBytes `json:"public_key"`
 }

--- a/back_end/block/block.go
+++ b/back_end/block/block.go
@@ -3,6 +3,8 @@ package block
 import (
 	"crypto/sha256"
 	"digital-voting/merkle_tree"
+	"digital-voting/signature/keys"
+	signatures "digital-voting/signature/signatures/single_signature"
 	tx "digital-voting/transaction"
 	"encoding/base64"
 	"time"
@@ -35,7 +37,7 @@ func NewBlock(txs []tx.ITransaction, previous [32]byte) *Block {
 	return block
 }
 
-func (b *Block) Sign(publicKey [33]byte, signature [65]byte) {
+func (b *Block) Sign(publicKey keys.PublicKeyBytes, signature signatures.SingleSignatureBytes) {
 	b.Witness.addSignature(publicKey, signature)
 }
 

--- a/back_end/block/block_test.go
+++ b/back_end/block/block_test.go
@@ -1,6 +1,8 @@
 package block
 
 import (
+	"digital-voting/signature/keys"
+	signatures "digital-voting/signature/signatures/single_signature"
 	"testing"
 	"time"
 )
@@ -29,8 +31,8 @@ func TestBlock(t *testing.T) {
 		t.Errorf("Got %s, instead of %s", got, expect)
 	}
 
-	var key = [33]byte{1, 2, 4, 41, 23}
-	var signature = [65]byte{6, 12, 9, 4, 3}
+	var key = keys.PublicKeyBytes{1, 2, 4, 41, 23}
+	var signature = signatures.SingleSignatureBytes{6, 12, 9, 4, 3}
 
 	b.Sign(key, signature)
 

--- a/back_end/block/witness.go
+++ b/back_end/block/witness.go
@@ -1,11 +1,16 @@
 package block
 
+import (
+	"digital-voting/signature/keys"
+	signature "digital-voting/signature/signatures/single_signature"
+)
+
 type Witness struct {
-	ValidatorsPublicKeys [][33]byte `json:"public_keys"`
-	ValidatorsSignatures [][65]byte `json:"signatures"`
+	ValidatorsPublicKeys []keys.PublicKeyBytes            `json:"public_keys"`
+	ValidatorsSignatures []signature.SingleSignatureBytes `json:"signatures"`
 }
 
-func (w *Witness) addSignature(publicKey [33]byte, signature [65]byte) {
+func (w *Witness) addSignature(publicKey keys.PublicKeyBytes, signature signature.SingleSignatureBytes) {
 	w.ValidatorsPublicKeys = append(w.ValidatorsPublicKeys, publicKey)
 	w.ValidatorsSignatures = append(w.ValidatorsSignatures, signature)
 }

--- a/back_end/identity_provider/identity_provider.go
+++ b/back_end/identity_provider/identity_provider.go
@@ -1,22 +1,24 @@
 package identity_provider
 
+import "digital-voting/signature/keys"
+
 type IdentityProvider struct {
-	UserPubKeys               map[[33]byte]struct{}
-	GroupIdentifiers          map[[33]byte]struct{}
-	RegistrationAdminPubKeys  map[[33]byte]struct{}
-	VotingCreatorAdminPubKeys map[[33]byte]struct{}
-	ValidatorPubKeys          map[[33]byte]struct{}
+	UserPubKeys               map[keys.PublicKeyBytes]struct{}
+	GroupIdentifiers          map[keys.PublicKeyBytes]struct{}
+	RegistrationAdminPubKeys  map[keys.PublicKeyBytes]struct{}
+	VotingCreatorAdminPubKeys map[keys.PublicKeyBytes]struct{}
+	ValidatorPubKeys          map[keys.PublicKeyBytes]struct{}
 }
 
 type PubKeyType int
 
 func NewIdentityProvider() *IdentityProvider {
 	return &IdentityProvider{
-		UserPubKeys:               map[[33]byte]struct{}{},
-		GroupIdentifiers:          map[[33]byte]struct{}{},
-		RegistrationAdminPubKeys:  map[[33]byte]struct{}{},
-		VotingCreatorAdminPubKeys: map[[33]byte]struct{}{},
-		ValidatorPubKeys:          map[[33]byte]struct{}{},
+		UserPubKeys:               map[keys.PublicKeyBytes]struct{}{},
+		GroupIdentifiers:          map[keys.PublicKeyBytes]struct{}{},
+		RegistrationAdminPubKeys:  map[keys.PublicKeyBytes]struct{}{},
+		VotingCreatorAdminPubKeys: map[keys.PublicKeyBytes]struct{}{},
+		ValidatorPubKeys:          map[keys.PublicKeyBytes]struct{}{},
 	}
 }
 
@@ -28,7 +30,7 @@ const (
 	Validator
 )
 
-func (ip *IdentityProvider) AddPubKey(publicKey [33]byte, keyType PubKeyType) {
+func (ip *IdentityProvider) AddPubKey(publicKey keys.PublicKeyBytes, keyType PubKeyType) {
 	switch keyType {
 	case User:
 		_, exists := ip.UserPubKeys[publicKey]
@@ -58,7 +60,7 @@ func (ip *IdentityProvider) AddPubKey(publicKey [33]byte, keyType PubKeyType) {
 	}
 }
 
-func (ip *IdentityProvider) CheckPubKeyPresence(publicKey [33]byte, keyType PubKeyType) bool {
+func (ip *IdentityProvider) CheckPubKeyPresence(publicKey keys.PublicKeyBytes, keyType PubKeyType) bool {
 	switch keyType {
 	case User:
 		_, exists := ip.UserPubKeys[publicKey]
@@ -80,7 +82,7 @@ func (ip *IdentityProvider) CheckPubKeyPresence(publicKey [33]byte, keyType PubK
 	}
 }
 
-func (ip *IdentityProvider) RemovePubKey(publicKey [33]byte, keyType PubKeyType) {
+func (ip *IdentityProvider) RemovePubKey(publicKey keys.PublicKeyBytes, keyType PubKeyType) {
 	switch keyType {
 	case User:
 		delete(ip.UserPubKeys, publicKey)

--- a/back_end/merkle_tree/transactions_merkle_tree_test.go
+++ b/back_end/merkle_tree/transactions_merkle_tree_test.go
@@ -1,7 +1,6 @@
 package merkle_tree
 
 import (
-	"crypto/sha256"
 	"digital-voting/account"
 	"digital-voting/signature/keys"
 	singleSignature "digital-voting/signature/signatures/single_signature"
@@ -14,7 +13,7 @@ import (
 func TestVerifyContent(t *testing.T) {
 	sign := singleSignature.NewECDSA()
 
-	keyPair1, _ := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair1, _ := keys.Random(sign.Curve)
 
 	transactions := []transaction.ITransaction{}
 
@@ -23,7 +22,7 @@ func TestVerifyContent(t *testing.T) {
 	transactions = append(transactions, myTransaction)
 
 	groupName := "EPS-41"
-	membersPublicKeys := [][33]byte{}
+	membersPublicKeys := []keys.PublicKeyBytes{}
 	membersPublicKeys = append(membersPublicKeys, keyPair1.PublicToBytes())
 	txBody1 := transaction_specific.NewTxGroupCreation(groupName, membersPublicKeys...)
 	transaction1 := transaction.NewTransaction(transaction.GroupCreation, txBody1)

--- a/back_end/signature/curve/curve.go
+++ b/back_end/signature/curve/curve.go
@@ -16,8 +16,8 @@ type ICurve interface {
 	NegPoint(P *Point) (*Point, error)
 	ComputeY(x *big.Int) *big.Int
 	ComputeDeterministicHash(P *Point) *Point
-	MarshalCompressed(point *Point) [33]byte
-	UnmarshalCompressed(data [33]byte) (point *Point)
+	MarshalCompressed(point *Point) PointCompressed
+	UnmarshalCompressed(data PointCompressed) (point *Point)
 }
 
 type Curve struct {
@@ -156,14 +156,14 @@ func (c *Curve) ComputeDeterministicHash(P *Point) *Point {
 	panic("should not be called")
 }
 
-func (c *Curve) MarshalCompressed(point *Point) [33]byte {
+func (c *Curve) MarshalCompressed(point *Point) PointCompressed {
 	if c.Name == "Curve25519" {
 		return c.ConvertToMontgomeryCurve().MarshalCompressed(point)
 	}
 	panic("should not be called")
 }
 
-func (c *Curve) UnmarshalCompressed(data [33]byte) (point *Point) {
+func (c *Curve) UnmarshalCompressed(data PointCompressed) (point *Point) {
 	if c.Name == "Curve25519" {
 		return c.ConvertToMontgomeryCurve().UnmarshalCompressed(data)
 	}

--- a/back_end/signature/curve/montgomery_curve.go
+++ b/back_end/signature/curve/montgomery_curve.go
@@ -123,7 +123,7 @@ func NewCurve25519() *MontgomeryCurve {
 	}
 }
 
-func (mc *MontgomeryCurve) MarshalCompressed(point *Point) [33]byte {
+func (mc *MontgomeryCurve) MarshalCompressed(point *Point) PointCompressed {
 	// TODO: think of different lengths
 	compressed := [33]byte{}
 	compressed[0] = byte(point.Y.Bit(0)) | 2
@@ -131,7 +131,7 @@ func (mc *MontgomeryCurve) MarshalCompressed(point *Point) [33]byte {
 	return compressed
 }
 
-func (mc *MontgomeryCurve) UnmarshalCompressed(data [33]byte) (point *Point) {
+func (mc *MontgomeryCurve) UnmarshalCompressed(data PointCompressed) (point *Point) {
 	// TODO: think of different lengths
 	result := &Point{nil, nil, mc}
 

--- a/back_end/signature/curve/montgomery_curve.go
+++ b/back_end/signature/curve/montgomery_curve.go
@@ -125,7 +125,7 @@ func NewCurve25519() *MontgomeryCurve {
 
 func (mc *MontgomeryCurve) MarshalCompressed(point *Point) PointCompressed {
 	// TODO: think of different lengths
-	compressed := [33]byte{}
+	compressed := PointCompressed{}
 	compressed[0] = byte(point.Y.Bit(0)) | 2
 	point.X.FillBytes(compressed[1:])
 	return compressed

--- a/back_end/signature/curve/point.go
+++ b/back_end/signature/curve/point.go
@@ -7,17 +7,19 @@ import (
 	"math/big"
 )
 
+type PointCompressed [33]byte
+
 type Point struct {
 	X     *big.Int
 	Y     *big.Int
 	Curve ICurve
 }
 
-func (p *Point) PointToBytes() [33]byte {
+func (p *Point) PointToBytes() PointCompressed {
 	return p.Curve.MarshalCompressed(p)
 }
 
-func BytesToPoint(data [33]byte, curve ICurve) *Point {
+func BytesToPoint(data PointCompressed, curve ICurve) *Point {
 	return curve.UnmarshalCompressed(data)
 }
 

--- a/back_end/signature/keys/key_pair_test.go
+++ b/back_end/signature/keys/key_pair_test.go
@@ -67,7 +67,7 @@ func TestPublicToBytes(t *testing.T) {
 		},
 		{
 			name:     "Incorrect conversion to bytes",
-			want:     [33]byte{12, 10, 11},
+			want:     PublicKeyBytes{12, 10, 11},
 			wantBool: false,
 		},
 	}

--- a/back_end/signature/keys/key_pair_test.go
+++ b/back_end/signature/keys/key_pair_test.go
@@ -12,10 +12,10 @@ func TestBytesToPublic(t *testing.T) {
 	keyPair1, _ := Random(montgomeryCurve)
 
 	publicKey := keyPair.GetPublicKey()
-	publicKeyBytes := publicKey.PointToBytes()
+	publicKeyBytes := keyPair.PublicToBytes()
 
 	type args struct {
-		data [33]byte
+		data PublicKeyBytes
 	}
 	tests := []struct {
 		name     string
@@ -53,12 +53,11 @@ func TestBytesToPublic(t *testing.T) {
 func TestPublicToBytes(t *testing.T) {
 	keyPair, _ := Random(curve.NewCurve25519())
 
-	publicKey := keyPair.GetPublicKey()
-	publicKeyBytes := publicKey.PointToBytes()
+	publicKeyBytes := keyPair.PublicToBytes()
 
 	tests := []struct {
 		name     string
-		want     [33]byte
+		want     PublicKeyBytes
 		wantBool bool
 	}{
 		{

--- a/back_end/signature/signatures/ring_signature/ring_signature_test.go
+++ b/back_end/signature/signatures/ring_signature/ring_signature_test.go
@@ -1,7 +1,7 @@
 package signatures
 
 import (
-	curve2 "digital-voting/signature/curve"
+	crv "digital-voting/signature/curve"
 	"digital-voting/signature/keys"
 	"log"
 	"math/big"
@@ -17,7 +17,7 @@ func TestVerifySignature(t *testing.T) {
 	}
 	publicKey := keyPair.GetPublicKey()
 
-	var publicKeys []*curve2.Point
+	var publicKeys []*crv.Point
 	publicKeys = append(publicKeys, publicKey)
 
 	for i := 0; i < 5; i++ {
@@ -42,7 +42,7 @@ func TestVerifySignature(t *testing.T) {
 		log.Panicln(err)
 	}
 
-	var publicKeys1 []*curve2.Point
+	var publicKeys1 []*crv.Point
 
 	for i := 0; i < 5; i++ {
 		tempKeyPair, err := keys.Random(sign.Curve)
@@ -53,13 +53,13 @@ func TestVerifySignature(t *testing.T) {
 	}
 
 	type fields struct {
-		KeyImage *curve2.Point
+		KeyImage *crv.Point
 		CList    []*big.Int
 		RList    []*big.Int
 	}
 	type args struct {
 		message    string
-		publicKeys []*curve2.Point
+		publicKeys []*crv.Point
 	}
 	tests := []struct {
 		name   string
@@ -136,16 +136,16 @@ func TestVerifySignature(t *testing.T) {
 
 func Test_getHash(t *testing.T) {
 	sign := NewECDSA_RS()
-	var lArray []*curve2.Point
-	var rArray []*curve2.Point
+	var lArray []*crv.Point
+	var rArray []*crv.Point
 
 	lArray = append(lArray, sign.GenPoint)
 	rArray = append(rArray, sign.GenPoint)
 
 	type args struct {
 		message string
-		lArray  []*curve2.Point
-		rArray  []*curve2.Point
+		lArray  []*crv.Point
+		rArray  []*crv.Point
 	}
 	tests := []struct {
 		name     string
@@ -192,7 +192,7 @@ func TestBytesToSignature(t *testing.T) {
 	}
 	publicKey := keyPair.GetPublicKey()
 
-	var publicKeys []*curve2.Point
+	var publicKeys []*crv.Point
 	publicKeys = append(publicKeys, publicKey)
 
 	for i := 0; i < 5; i++ {
@@ -257,7 +257,7 @@ func TestSignatureToBytes(t *testing.T) {
 	}
 	publicKey := keyPair.GetPublicKey()
 
-	var publicKeys []*curve2.Point
+	var publicKeys []*crv.Point
 	publicKeys = append(publicKeys, publicKey)
 
 	for i := 0; i < 5; i++ {

--- a/back_end/signature/signatures/ring_signature/ring_signature_test.go
+++ b/back_end/signature/signatures/ring_signature/ring_signature_test.go
@@ -1,19 +1,17 @@
 package signatures
 
 import (
-	"crypto/sha256"
 	curve2 "digital-voting/signature/curve"
 	"digital-voting/signature/keys"
 	"log"
 	"math/big"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func TestVerifySignature(t *testing.T) {
 	sign := NewECDSA_RS()
-	keyPair, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair, err := keys.Random(sign.Curve)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -23,7 +21,7 @@ func TestVerifySignature(t *testing.T) {
 	publicKeys = append(publicKeys, publicKey)
 
 	for i := 0; i < 5; i++ {
-		tempKeyPair, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+		tempKeyPair, err := keys.Random(sign.Curve)
 		if err != nil {
 			log.Panicln(err)
 		}
@@ -38,7 +36,7 @@ func TestVerifySignature(t *testing.T) {
 		log.Panicln(err)
 	}
 
-	keyPair1, _ := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair1, _ := keys.Random(sign.Curve)
 	ringSignature1, err := sign.Sign(message, keyPair1, publicKeys, s)
 	if err != nil {
 		log.Panicln(err)
@@ -47,7 +45,7 @@ func TestVerifySignature(t *testing.T) {
 	var publicKeys1 []*curve2.Point
 
 	for i := 0; i < 5; i++ {
-		tempKeyPair, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+		tempKeyPair, err := keys.Random(sign.Curve)
 		if err != nil {
 			log.Panicln(err)
 		}
@@ -188,7 +186,7 @@ func Test_getHash(t *testing.T) {
 func TestBytesToSignature(t *testing.T) {
 	sign := NewECDSA_RS()
 
-	keyPair, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair, err := keys.Random(sign.Curve)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -198,7 +196,7 @@ func TestBytesToSignature(t *testing.T) {
 	publicKeys = append(publicKeys, publicKey)
 
 	for i := 0; i < 5; i++ {
-		tempKeyPair, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+		tempKeyPair, err := keys.Random(sign.Curve)
 		if err != nil {
 			log.Panicln(err)
 		}
@@ -213,8 +211,8 @@ func TestBytesToSignature(t *testing.T) {
 	sigBytes1, image1 := signature1.SignatureToBytes()
 
 	type args struct {
-		data     [][65]byte
-		keyImage [33]byte
+		data     RingSignatureBytes
+		keyImage KeyImageBytes
 	}
 	tests := []struct {
 		name     string
@@ -253,7 +251,7 @@ func TestBytesToSignature(t *testing.T) {
 func TestSignatureToBytes(t *testing.T) {
 	sign := NewECDSA_RS()
 
-	keyPair, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair, err := keys.Random(sign.Curve)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -263,7 +261,7 @@ func TestSignatureToBytes(t *testing.T) {
 	publicKeys = append(publicKeys, publicKey)
 
 	for i := 0; i < 5; i++ {
-		tempKeyPair, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+		tempKeyPair, err := keys.Random(sign.Curve)
 		if err != nil {
 			log.Panicln(err)
 		}
@@ -279,8 +277,8 @@ func TestSignatureToBytes(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		want     [][65]byte
-		want1    [33]byte
+		want     RingSignatureBytes
+		want1    KeyImageBytes
 		wantBool bool
 	}{
 		{

--- a/back_end/signature/signatures/single_signature/single_signature.go
+++ b/back_end/signature/signatures/single_signature/single_signature.go
@@ -3,7 +3,7 @@ package signatures
 import (
 	crypto "crypto/rand"
 	"crypto/sha1"
-	curve2 "digital-voting/signature/curve"
+	crv "digital-voting/signature/curve"
 	"digital-voting/signature/keys"
 	"digital-voting/signature/signatures/utils"
 	"encoding/hex"
@@ -14,12 +14,12 @@ import (
 )
 
 type ECDSA struct {
-	GenPoint *curve2.Point
-	Curve    *curve2.MontgomeryCurve
+	GenPoint *crv.Point
+	Curve    *crv.MontgomeryCurve
 }
 
 func NewECDSA() *ECDSA {
-	curve := curve2.NewCurve25519()
+	curve := crv.NewCurve25519()
 	return &ECDSA{
 		GenPoint: curve.G(),
 		Curve:    curve,
@@ -99,13 +99,13 @@ func (ec *ECDSA) Sign(message string, privateKey *big.Int) *SingleSignature {
 }
 
 func (ec *ECDSA) VerifyBytes(message string, publicKey keys.PublicKeyBytes, signature SingleSignatureBytes) bool {
-	pubKey := curve2.BytesToPoint(curve2.PointCompressed(publicKey), ec.Curve)
+	pubKey := crv.BytesToPoint(crv.PointCompressed(publicKey), ec.Curve)
 	sig := BytesToSignature(signature)
 
 	return ec.Verify(message, pubKey, sig)
 }
 
-func (ec *ECDSA) Verify(message string, publicKey *curve2.Point, signature *SingleSignature) bool {
+func (ec *ECDSA) Verify(message string, publicKey *crv.Point, signature *SingleSignature) bool {
 	// 1. Verify that r and s are integers in the interval [1, n - 1].
 	if !utils.CheckInterval(signature.R, utils.GetInt(1), new(big.Int).Sub(ec.Curve.N, utils.GetInt(1))) ||
 		!utils.CheckInterval(signature.S, utils.GetInt(1), new(big.Int).Sub(ec.Curve.N, utils.GetInt(1))) {

--- a/back_end/signature/signatures/single_signature/single_signature_test.go
+++ b/back_end/signature/signatures/single_signature/single_signature_test.go
@@ -200,7 +200,7 @@ func TestSignatureToBytes(t *testing.T) {
 		},
 		{
 			name:     "Incorrect conversion to bytes",
-			want:     [65]byte{12, 10, 11},
+			want:     SingleSignatureBytes{12, 10, 11},
 			wantBool: false,
 		},
 	}

--- a/back_end/signature/signatures/single_signature/single_signature_test.go
+++ b/back_end/signature/signatures/single_signature/single_signature_test.go
@@ -1,24 +1,22 @@
 package signatures
 
 import (
-	"crypto/sha256"
 	"digital-voting/signature/curve"
 	"digital-voting/signature/keys"
 	"log"
 	"math/big"
 	"reflect"
 	"testing"
-	"time"
 )
 
 func TestKeyGeneration(t *testing.T) {
 	sign := NewECDSA()
-	keyPair1, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair1, err := keys.Random(sign.Curve)
 	if err != nil {
 		log.Panicln(err)
 	}
 
-	keyPair2, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair2, err := keys.Random(sign.Curve)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -39,12 +37,12 @@ func TestKeyGeneration(t *testing.T) {
 
 func TestVerify(t *testing.T) {
 	sign := NewECDSA()
-	keyPair1, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair1, err := keys.Random(sign.Curve)
 	if err != nil {
 		log.Panicln(err)
 	}
 
-	keyPair2, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair2, err := keys.Random(sign.Curve)
 	if err != nil {
 		log.Panicln(err)
 	}
@@ -139,7 +137,7 @@ func TestVerify(t *testing.T) {
 
 func TestBytesToSignature(t *testing.T) {
 	sign := NewECDSA()
-	keyPair, _ := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair, _ := keys.Random(sign.Curve)
 	message := "1"
 
 	signature := sign.Sign(message, keyPair.GetPrivateKey())
@@ -148,7 +146,7 @@ func TestBytesToSignature(t *testing.T) {
 	signature1 := sign.Sign(message+"1", keyPair.GetPrivateKey())
 
 	type args struct {
-		data [65]byte
+		data SingleSignatureBytes
 	}
 	tests := []struct {
 		name     string
@@ -184,7 +182,7 @@ func TestBytesToSignature(t *testing.T) {
 
 func TestSignatureToBytes(t *testing.T) {
 	sign := NewECDSA()
-	keyPair, _ := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair, _ := keys.Random(sign.Curve)
 	message := "1"
 
 	signature := sign.Sign(message, keyPair.GetPrivateKey())
@@ -192,7 +190,7 @@ func TestSignatureToBytes(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		want     [65]byte
+		want     SingleSignatureBytes
 		wantBool bool
 	}{
 		{

--- a/back_end/signer/block_signer.go
+++ b/back_end/signer/block_signer.go
@@ -20,5 +20,5 @@ func (bs *BlockSigner) SignBlock(keyPair *keys.KeyPair, block *block.Block) {
 	messageToSign := block.GetHashString()
 
 	signature := bs.BlkSigner.Sign(messageToSign, privateKey)
-	block.Sign(publicKey.PointToBytes(), signature.SignatureToBytes())
+	block.Sign(keys.PublicKeyBytes(publicKey.PointToBytes()), signature.SignatureToBytes())
 }

--- a/back_end/signer/transaction_signer.go
+++ b/back_end/signer/transaction_signer.go
@@ -35,9 +35,9 @@ func (ts *TransactionSigner) SignTransactionAnonymous(keyPair *keys.KeyPair, pub
 		log.Panicln(err)
 	}
 
-	pKeysData := make([][33]byte, len(publicKeys))
+	pKeysData := make([]keys.PublicKeyBytes, len(publicKeys))
 	for i := 0; i < len(pKeysData); i++ {
-		pKeysData[i] = publicKeys[i].PointToBytes()
+		pKeysData[i] = keys.PublicKeyBytes(publicKeys[i].PointToBytes())
 	}
 
 	rSigData, keyImage := rSignature.SignatureToBytes()

--- a/back_end/transaction/transaction.go
+++ b/back_end/transaction/transaction.go
@@ -3,6 +3,7 @@ package transaction
 import (
 	"crypto/sha256"
 	"digital-voting/identity_provider"
+	"digital-voting/signature/keys"
 	singleSignature "digital-voting/signature/signatures/single_signature"
 	"encoding/base64"
 	"encoding/json"
@@ -22,19 +23,19 @@ const (
 )
 
 type Transaction struct {
-	TxType    TxType   `json:"tx_type"`
-	TxBody    TxBody   `json:"tx_body"`
-	Data      []byte   `json:"data"`
-	Nonce     uint32   `json:"nonce"`
-	Signature [65]byte `json:"signature"`
-	PublicKey [33]byte `json:"public_key"`
+	TxType    TxType                               `json:"tx_type"`
+	TxBody    TxBody                               `json:"tx_body"`
+	Data      []byte                               `json:"data"`
+	Nonce     uint32                               `json:"nonce"`
+	Signature singleSignature.SingleSignatureBytes `json:"signature"`
+	PublicKey keys.PublicKeyBytes                  `json:"public_key"`
 }
 
 func (tx *Transaction) GetTxType() TxType {
 	return tx.TxType
 }
 
-func (tx *Transaction) Sign(publicKey [33]byte, signature [65]byte) {
+func (tx *Transaction) Sign(publicKey keys.PublicKeyBytes, signature singleSignature.SingleSignatureBytes) {
 	tx.Signature = signature
 	tx.PublicKey = publicKey
 }

--- a/back_end/transaction/transaction_body.go
+++ b/back_end/transaction/transaction_body.go
@@ -1,9 +1,12 @@
 package transaction
 
-import "digital-voting/identity_provider"
+import (
+	"digital-voting/identity_provider"
+	"digital-voting/signature/keys"
+)
 
 type TxBody interface {
 	GetSignatureMessage() string
 	Validate(identityProvider *identity_provider.IdentityProvider) bool
-	CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey [33]byte) bool
+	CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey keys.PublicKeyBytes) bool
 }

--- a/back_end/transaction/transaction_specific/tx_account_creation.go
+++ b/back_end/transaction/transaction_specific/tx_account_creation.go
@@ -4,17 +4,18 @@ import (
 	"crypto/sha256"
 	"digital-voting/account"
 	"digital-voting/identity_provider"
+	"digital-voting/signature/keys"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 )
 
 type TxAccountCreation struct {
-	AccountType  account.Type `json:"account_type"`
-	NewPublicKey [33]byte     `json:"new_public_key"`
+	AccountType  account.Type        `json:"account_type"`
+	NewPublicKey keys.PublicKeyBytes `json:"new_public_key"`
 }
 
-func NewTxAccCreation(accountType account.Type, newPublicKey [33]byte) *TxAccountCreation {
+func NewTxAccCreation(accountType account.Type, newPublicKey keys.PublicKeyBytes) *TxAccountCreation {
 	return &TxAccountCreation{AccountType: accountType, NewPublicKey: newPublicKey}
 }
 
@@ -44,7 +45,7 @@ func (tx *TxAccountCreation) IsEqual(otherTransaction *TxAccountCreation) bool {
 	return tx.GetHash() == otherTransaction.GetHash()
 }
 
-func (tx *TxAccountCreation) CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey [33]byte) bool {
+func (tx *TxAccountCreation) CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey keys.PublicKeyBytes) bool {
 	return identityProvider.CheckPubKeyPresence(publicKey, identity_provider.RegistrationAdmin)
 }
 

--- a/back_end/transaction/transaction_specific/tx_group_creation.go
+++ b/back_end/transaction/transaction_specific/tx_group_creation.go
@@ -3,18 +3,19 @@ package transaction_specific
 import (
 	"crypto/sha256"
 	"digital-voting/identity_provider"
+	"digital-voting/signature/keys"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 )
 
 type TxGroupCreation struct {
-	GroupIdentifier   [33]byte   `json:"group_identifier"`
-	GroupName         [256]byte  `json:"group_name"`
-	MembersPublicKeys [][33]byte `json:"members_public_keys"`
+	GroupIdentifier   [33]byte              `json:"group_identifier"`
+	GroupName         [256]byte             `json:"group_name"`
+	MembersPublicKeys []keys.PublicKeyBytes `json:"members_public_keys"`
 }
 
-func NewTxGroupCreation(groupName string, membersPublicKeys ...[33]byte) *TxGroupCreation {
+func NewTxGroupCreation(groupName string, membersPublicKeys ...keys.PublicKeyBytes) *TxGroupCreation {
 	grpName := [256]byte{}
 	copy(grpName[:], groupName)
 
@@ -31,11 +32,11 @@ func NewTxGroupCreation(groupName string, membersPublicKeys ...[33]byte) *TxGrou
 	return &TxGroupCreation{GroupIdentifier: grpId, GroupName: grpName, MembersPublicKeys: membersPublicKeys}
 }
 
-func (tx *TxGroupCreation) AddGroupMember(publicKey [33]byte) {
+func (tx *TxGroupCreation) AddGroupMember(publicKey keys.PublicKeyBytes) {
 	tx.MembersPublicKeys = append(tx.MembersPublicKeys, publicKey)
 }
 
-func (tx *TxGroupCreation) RemoveGroupMember(publicKey [33]byte) {
+func (tx *TxGroupCreation) RemoveGroupMember(publicKey keys.PublicKeyBytes) {
 	for i, key := range tx.MembersPublicKeys {
 		//it works for [33]byte
 		if key == publicKey {
@@ -71,7 +72,7 @@ func (tx *TxGroupCreation) IsEqual(otherTransaction *TxGroupCreation) bool {
 	return tx.GetHash() == otherTransaction.GetHash()
 }
 
-func (tx *TxGroupCreation) CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey [33]byte) bool {
+func (tx *TxGroupCreation) CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey keys.PublicKeyBytes) bool {
 	return identityProvider.CheckPubKeyPresence(publicKey, identity_provider.RegistrationAdmin)
 }
 

--- a/back_end/transaction/transaction_specific/tx_vote.go
+++ b/back_end/transaction/transaction_specific/tx_vote.go
@@ -3,6 +3,7 @@ package transaction_specific
 import (
 	"crypto/sha256"
 	"digital-voting/identity_provider"
+	"digital-voting/signature/keys"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -43,7 +44,7 @@ func (tx *TxVote) IsEqual(otherTransaction *TxVote) bool {
 	return tx.GetHash() == otherTransaction.GetHash()
 }
 
-func (tx *TxVote) CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey [33]byte) bool {
+func (tx *TxVote) CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey keys.PublicKeyBytes) bool {
 	return identityProvider.CheckPubKeyPresence(publicKey, identity_provider.User)
 }
 

--- a/back_end/transaction/transaction_specific/tx_vote_anonymus.go
+++ b/back_end/transaction/transaction_specific/tx_vote_anonymus.go
@@ -3,6 +3,7 @@ package transaction_specific
 import (
 	"crypto/sha256"
 	"digital-voting/identity_provider"
+	"digital-voting/signature/keys"
 	ringSignature "digital-voting/signature/signatures/ring_signature"
 	tx "digital-voting/transaction"
 	"encoding/base64"
@@ -13,14 +14,14 @@ import (
 )
 
 type TxVoteAnonymous struct {
-	TxType        tx.TxType  `json:"tx_type"`
-	VotingLink    [32]byte   `json:"voting_link"`
-	Answer        uint8      `json:"answer"`
-	Data          []byte     `json:"data"`
-	Nonce         uint32     `json:"nonce"`
-	RingSignature [][65]byte `json:"ring_signature"`
-	KeyImage      [33]byte   `json:"key_image"`
-	PublicKeys    [][33]byte `json:"public_keys"`
+	TxType        tx.TxType                        `json:"tx_type"`
+	VotingLink    [32]byte                         `json:"voting_link"`
+	Answer        uint8                            `json:"answer"`
+	Data          []byte                           `json:"data"`
+	Nonce         uint32                           `json:"nonce"`
+	RingSignature ringSignature.RingSignatureBytes `json:"ring_signature"`
+	KeyImage      ringSignature.KeyImageBytes      `json:"key_image"`
+	PublicKeys    []keys.PublicKeyBytes            `json:"public_keys"`
 }
 
 func (tx *TxVoteAnonymous) GetTxType() tx.TxType {
@@ -31,7 +32,7 @@ func NewTxVoteAnonymous(votingLink [32]byte, answer uint8) *TxVoteAnonymous {
 	return &TxVoteAnonymous{TxType: tx.VoteAnonymous, VotingLink: votingLink, Answer: answer, Nonce: uint32(rand.Int())}
 }
 
-func (tx *TxVoteAnonymous) Sign(publicKeys [][33]byte, signature [][65]byte, keyImage [33]byte) {
+func (tx *TxVoteAnonymous) Sign(publicKeys []keys.PublicKeyBytes, signature ringSignature.RingSignatureBytes, keyImage ringSignature.KeyImageBytes) {
 	tx.PublicKeys = publicKeys
 	tx.RingSignature = signature
 	tx.KeyImage = keyImage

--- a/back_end/transaction/transaction_specific/tx_voting_creation.go
+++ b/back_end/transaction/transaction_specific/tx_voting_creation.go
@@ -3,6 +3,7 @@ package transaction_specific
 import (
 	"crypto/sha256"
 	"digital-voting/identity_provider"
+	"digital-voting/signature/keys"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -13,7 +14,8 @@ type TxVotingCreation struct {
 	ExpirationDate    uint32      `json:"expiration_date"`
 	VotingDescription [1024]byte  `json:"voting_description"`
 	Answers           [][256]byte `json:"answers"`
-	Whitelist         [][33]byte  `json:"whitelist"`
+	// Not a keys.PublicKeyBytes since it can be group identifier as well
+	Whitelist [][33]byte `json:"whitelist"`
 }
 
 func NewTxVotingCreation(expirationDate time.Time, votingDescription string, answers []string, whitelist [][33]byte) *TxVotingCreation {
@@ -56,7 +58,7 @@ func (tx *TxVotingCreation) IsEqual(otherTransaction *TxAccountCreation) bool {
 	return tx.GetHash() == otherTransaction.GetHash()
 }
 
-func (tx *TxVotingCreation) CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey [33]byte) bool {
+func (tx *TxVotingCreation) CheckPublicKeyByRole(identityProvider *identity_provider.IdentityProvider, publicKey keys.PublicKeyBytes) bool {
 	return identityProvider.CheckPubKeyPresence(publicKey, identity_provider.VotingCreationAdmin)
 }
 

--- a/back_end/validation/transaction_validation_test.go
+++ b/back_end/validation/transaction_validation_test.go
@@ -1,10 +1,9 @@
 package validation
 
 import (
-	"crypto/sha256"
 	"digital-voting/account"
 	"digital-voting/identity_provider"
-	curve "digital-voting/signature/curve"
+	"digital-voting/signature/curve"
 	"digital-voting/signature/keys"
 	singleSignature "digital-voting/signature/signatures/single_signature"
 	"digital-voting/signer"
@@ -20,18 +19,18 @@ func TestValidateTransaction(t *testing.T) {
 	txSigner := signer.NewTransactionSigner()
 	identityProvider := identity_provider.NewIdentityProvider()
 
-	keyPair1, _ := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair1, _ := keys.Random(sign.Curve)
 	identityProvider.AddPubKey(keyPair1.PublicToBytes(), identity_provider.User)
 	identityProvider.AddPubKey(keyPair1.PublicToBytes(), identity_provider.VotingCreationAdmin)
 	identityProvider.AddPubKey(keyPair1.PublicToBytes(), identity_provider.RegistrationAdmin)
 
-	keyPair2, _ := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair2, _ := keys.Random(sign.Curve)
 	accCreationBody := transaction_specific.NewTxAccCreation(account.RegistrationAdmin, keyPair2.PublicToBytes())
 	txAccountCreation := transaction.NewTransaction(transaction.AccountCreation, accCreationBody)
 	txSigner.SignTransaction(keyPair1, txAccountCreation)
 
 	groupName := "EPS-41"
-	membersPublicKeys := [][33]byte{}
+	membersPublicKeys := []keys.PublicKeyBytes{}
 	membersPublicKeys = append(membersPublicKeys, keyPair1.PublicToBytes())
 	grpCreationBody := transaction_specific.NewTxGroupCreation(groupName, membersPublicKeys...)
 	txGroupCreation := transaction.NewTransaction(transaction.GroupCreation, grpCreationBody)
@@ -52,7 +51,7 @@ func TestValidateTransaction(t *testing.T) {
 	var publicKeys []*curve.Point
 	publicKeys = append(publicKeys, keyPair1.GetPublicKey())
 	for i := 0; i < 5; i++ {
-		tempKeyPair, err := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+		tempKeyPair, err := keys.Random(sign.Curve)
 		if err != nil {
 			log.Panicln(err)
 		}

--- a/back_end/validation/validator.go
+++ b/back_end/validation/validator.go
@@ -13,7 +13,7 @@ import (
 
 type Validator struct {
 	KeyPair              *keys.KeyPair
-	ValidatorsPublicKeys map[[33]byte]struct{}
+	ValidatorsPublicKeys map[keys.PublicKeyBytes]struct{}
 	// TODO: think of data structure to store in future
 	ValidatorsAddresses []any
 	MemPool             []transaction.ITransaction
@@ -54,11 +54,13 @@ func (v *Validator) CreateBlock(previousBlockHash [32]byte) *block.Block {
 		MerkleRoot: merkle_tree.GetMerkleRoot(blockBody.Transactions),
 	}
 
-	// Sign block
+	// Create block itself
 	newBlock := &block.Block{
 		Header: blockHeader,
 		Body:   blockBody,
 	}
+
+	// Sign block
 	v.SignBlock(newBlock)
 
 	return newBlock

--- a/back_end/validation/validator_test.go
+++ b/back_end/validation/validator_test.go
@@ -1,7 +1,6 @@
 package validation
 
 import (
-	"crypto/sha256"
 	"digital-voting/account"
 	"digital-voting/block"
 	"digital-voting/identity_provider"
@@ -18,8 +17,8 @@ func TestIsInMemPool(t *testing.T) {
 	v := &Validator{}
 
 	groupName := "EPS-41"
-	membersPublicKeys := [][33]byte{}
-	membersPublicKeys = append(membersPublicKeys, [33]byte{1, 2, 3})
+	membersPublicKeys := []keys.PublicKeyBytes{}
+	membersPublicKeys = append(membersPublicKeys, keys.PublicKeyBytes{1, 2, 3})
 	grpCreationBody := transaction_specific.NewTxGroupCreation(groupName, membersPublicKeys...)
 	txGroupCreation := transaction.NewTransaction(transaction.GroupCreation, grpCreationBody)
 	v.MemPool = append(v.MemPool, txGroupCreation)
@@ -32,7 +31,7 @@ func TestIsInMemPool(t *testing.T) {
 	txVotingCreation := transaction.NewTransaction(transaction.VotingCreation, votingCreationBody)
 	v.MemPool = append(v.MemPool, txVotingCreation)
 
-	accCreationBody := transaction_specific.NewTxAccCreation(account.RegistrationAdmin, [33]byte{1, 2, 3})
+	accCreationBody := transaction_specific.NewTxAccCreation(account.RegistrationAdmin, keys.PublicKeyBytes{1, 2, 3})
 	txAccountCreation := transaction.NewTransaction(transaction.AccountCreation, accCreationBody)
 
 	type args struct {
@@ -71,19 +70,19 @@ func TestCreateBlock(t *testing.T) {
 	sign := singleSignature.NewECDSA()
 	txSigner := signer.NewTransactionSigner()
 	identityProvider := identity_provider.NewIdentityProvider()
-	keyPair1, _ := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair1, _ := keys.Random(sign.Curve)
 
 	identityProvider.AddPubKey(keyPair1.PublicToBytes(), identity_provider.User)
 	identityProvider.AddPubKey(keyPair1.PublicToBytes(), identity_provider.VotingCreationAdmin)
 	identityProvider.AddPubKey(keyPair1.PublicToBytes(), identity_provider.RegistrationAdmin)
 
-	keyPair2, _ := keys.FromRawSeed(sha256.Sum256([]byte(time.Now().String())), sign.Curve)
+	keyPair2, _ := keys.Random(sign.Curve)
 	accCreationBody := transaction_specific.NewTxAccCreation(account.RegistrationAdmin, keyPair2.PublicToBytes())
 	txAccountCreation := transaction.NewTransaction(transaction.AccountCreation, accCreationBody)
 	txSigner.SignTransaction(keyPair1, txAccountCreation)
 
 	groupName := "EPS-41"
-	membersPublicKeys := [][33]byte{}
+	membersPublicKeys := []keys.PublicKeyBytes{}
 	membersPublicKeys = append(membersPublicKeys, keyPair1.PublicToBytes())
 	grpCreationBody := transaction_specific.NewTxGroupCreation(groupName, membersPublicKeys...)
 	txGroupCreation := transaction.NewTransaction(transaction.GroupCreation, grpCreationBody)


### PR DESCRIPTION
PublicKeyBytes, KeyImage and PointCompressed for [33]byte in keys, signature and curve packages respectively.
SingleSignatureBytes for [65]byte in signature package.
RingSignatureBytes for [][65]byte in signature package.

Changed usage of these values raw to their aliases in all files.

Changed key generation in all tests to Random(curve ICurve).
Fixed import names for curve (curve2 -> crv).
Got rid of unused sign function in keys package.